### PR TITLE
Enhancements to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ WARNING: This is a work in progress!
   - [Overview](#overview)
     - [What is the Azure OpenAI API Simulator?](#what-is-the-azure-openai-api-simulator)
     - [Simulator Modes](#simulator-modes)
-      - [Record/Replay Mode](#recordreplay-mode)
-      - [Generator Mode](#generator-mode)
-  - [When to use the simulator](#when-to-use-the-simulator)
-  - [Read More](#read-more)
+  - [When to use the Azure OpenAI API Simulator](#when-to-use-the-azure-openai-api-simulator)
+  - [How to Get Started with the Azure OpenAI API Simulator](#how-to-get-started-with-the-azure-openai-api-simulator)
+    - [Running and Deploying the Azure OpenAI API Simulator](#running-and-deploying-the-azure-openai-api-simulator)
+    - [Configuring the Azure OpenAI API Simulator](#configuring-the-azure-openai-api-simulator)
+    - [Extending the Azure OpenAI API Simulator](#extending-the-azure-openai-api-simulator)
+    - [Contributing to the Azure OpenAI API Simulator](#contributing-to-the-azure-openai-api-simulator)
   - [Changelog](#changelog)
   - [Contributing](#contributing)
   - [Trademarks](#trademarks)
@@ -24,9 +26,11 @@ WARNING: This is a work in progress!
 ### What is the Azure OpenAI API Simulator?
 
 The Azure OpenAI API Simulator is a tool that allows you to easily deploy endpoints that simulate the OpenAI API.
-A common use-case for the simulator is to test the behaviour your application under load. Let's illustrate this with an example...
+A common use-case for the simulator is to test the behaviour your application under load, without making calls to the live OpenAI API endpoints. 
 
-Let's assume that you have build a chatbot that uses the OpenAI API to generate responses to user queries. Before your chatbot becomes popular, you want to ensure that it can handle a large number of users. One of the factors that will impact whether your chatbot can gracefully handle such load will be the way that your chatbot handles calls to OpenAI. However, when load testing your chatbot there are a number of reasons why you might not want to call the OpenAI API directly:
+Let's illustrate this with an example...
+
+Let's assume that you have built a chatbot that uses the OpenAI API to generate responses to user queries. Before your chatbot becomes popular, you want to ensure that it can handle a large number of users. One of the factors that will impact whether your chatbot can gracefully handle such load will be the way that your chatbot handles calls to OpenAI. However, when load testing your chatbot there are a number of reasons why you might not want to call the OpenAI API directly:
 
 - **Cost**: The OpenAI API is a paid service, and running load tests against it can be expensive.
 - **Consistency**: The OpenAI API is a live service, and the responses you get back can change over time. This can make it difficult to compare the results of load tests run at different times.
@@ -35,49 +39,60 @@ Let's assume that you have build a chatbot that uses the OpenAI API to generate 
 
 In fact, when considering Rate Limits and Latency, these might be things that you'd like to control. You may also want to inject latency, or inject rate limit issues, so that you can test how your chatbot deals with these issues.
 
-**This is where the Azure OpenAI API Simulator plays it's part!**
+**This is where the Azure OpenAI API Simulator plays its part!**
 
-By using the Azure OpenAI API Simulator, you can reduce the cost of running load tests against the OpenAI API and ensure that your application behaves as expected under different conditions.
+By using the Azure OpenAI API Simulator, instead of the live OpenAI API, you can reduce the cost of running load tests against the OpenAI API and ensure that your application behaves as expected under different conditions.
+
+The `Azure OpenAI API Simulator presents the same interface as the live OpenAI API, allowing you to easily switch between the two, and then gives you full control over the responses that are returned.
 
 ### Simulator Modes
 
-The simulator has two approaches to simulating API responses: record/replay and generators.
-If you don't have any requirements around the content of the responses, the generator approach is probably the easiest for  you to use.
-If you need to simulate specific responses, then the record/replay approach is likely the best fit for you.
+The Azure OpenAI API Simulator has two approaches to simulating API responses: 
 
-#### Record/Replay Mode
-
-With record/replay, the API can be run in record mode to act as a proxy between your application and Azure OpenAI, and it will record requests that are sent to it along with the corresponding response from OpenAI. 
-
-
-![Simulator in record mode](./docs/images/mode-record.drawio.png "The Simulator in record mode proxying requests to Azure OpenAI and persisting the responses to disk")
-
-Once recorded, the API can be run in replay mode to use the saved responses without forwarding to Azure OpenAI. The recordings are stored in YAML files which can be edited if you want to customise the responses.
-
-![Simulator in replay mode](./docs/images/mode-replay.drawio.png "The Simulator in replay mode reading responses from disk and returning them to the client")
+1. **Generator Mode** - If you don't have any requirements around the content of the responses, the **Generator** approach is probably the easiest for you to use.
+2. **Record/Replay Mode** - If you need to simulate specific responses, then the **Record/Replay** approach is likely the best fit for you.
 
 #### Generator Mode
 
-The simulated API can also be run in generator mode, where responses are generated on the fly. This is useful for load testing scenarios where it would be costly/impractical to record the full set of responses.
+When run in Generator mode the Azure OpenAI API Simulator will create responses to requests on the fly. This mode is useful for load testing scenarios where it would be costly/impractical to record the full set of responses, or where the content of the response is not critical to the load testing.
 
 ![Simulator in generator mode](./docs/images/mode-generate.drawio.png "The Simulator in generate mode showing lorem ipsum generated content in the response")
 
-## When to use the simulator
+#### Record/Replay Mode
 
-The simulator has been used in the following scenarios:
+With record/replay, the Azure OpenAI API Simulator is set up to act as a proxy between your application and Azure OpenAI. The Azure OpenAI API Simulator will then record requests that are sent to it along with the corresponding response from OpenAI API. 
 
-- **Load Testing**: The simulator can be used to simulate the Azure OpenAI API in a development environment, allowing you to test how your application behaves under load. This can be useful both to save money when load testing or to allow you to test scaling the system beyond the Azure OpenAI capacity available in your development environment
-- **Integration Testing**: The simulator can be used to run integration tests, for example in CI builds without needing to have credentials for an Azure OpenAI endpoint
+![Simulator in record mode](./docs/images/mode-record.drawio.png "The Simulator in record mode proxying requests to Azure OpenAI and persisting the responses to disk")
 
-The simulator is not a replacement for testing against the real Azure OpenAI API, but it can be a useful tool in your testing toolbox.
+Once a set of recordings have been made, the Azure OpenAI API Simulator can then be run in replay mode where it uses these saved responses without forwarding anything to the OpenAI API. 
 
-## Read More
+Recordings are stored in YAML files which can be edited if you want to customise the responses.
 
-There are various options for [running and deploying](./docs/running-deploying.md) the simulator, including running in Docker and deploying to Azure Container Apps.
+![Simulator in replay mode](./docs/images/mode-replay.drawio.png "The Simulator in replay mode reading responses from disk and returning them to the client")
 
-There are a range of [configuration options](./docs/config.md) that can be applied to control the simulator behavior.
+## When to use the Azure OpenAI API Simulator
 
-The simulated API supports [extensions](./docs/extensions.md) that allow you to customise the behaviour of the API. Extensions can be used to modify the request/response, add latency, or even generate responses.
+The Azure OpenAI API Simulator has been used in the following scenarios:
+
+- **Load Testing**: The Azure OpenAI API Simulator can be used to simulate the Azure OpenAI API in a development environment, allowing you to test how your application behaves under load. This can be useful both to save money when load testing or to allow you to test scaling the system beyond the Azure OpenAI capacity available in your development environment
+- **Integration Testing**: The Azure OpenAI API Simulator can be used to run integration tests, for example in CI builds without needing to have credentials for an Azure OpenAI endpoint
+
+The Azure OpenAI API Simulator is not a replacement for testing against the real Azure OpenAI API, but it can be a useful tool in your testing toolbox.
+
+## How to Get Started with the Azure OpenAI API Simulator
+
+### Running and Deploying the Azure OpenAI API Simulator
+To document [Running and Deploying the Azure OpenAI API Simulator](./docs/running-deploying.md) includes instructions on running the Azure OpenAI API Simulator locally, packaging and deploying it in a Docker container, and also deploying the Azure OpenAI API Simulator to Azure Container Apps.
+
+### Configuring the Azure OpenAI API Simulator
+The behavious of the Azure OpenAI API Simulator is controlled via a range of [Azure OpenAI API Simulator Configuration Options](./docs/config.md).
+
+### Extending the Azure OpenAI API Simulator
+There are also a number of [Azure OpenAI API Simulator Extensions](./docs/extensions.md) that allow you to customise the behaviour of the Azure OpenAI API Simulator. Extensions can be used to modify the request/response, add latency, or even generate responses.
+
+### Contributing to the Azure OpenAI API Simulator
+
+Finally, if you're looking to contribute to the Azure OpenAI API Simulator you should refer to the [Azure OpenAI API Simulator Development Guide](./docs/developing.md).
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The Azure OpenAI API Simulator is not a replacement for testing against the real
 ## How to Get Started with the Azure OpenAI API Simulator
 
 ### Running and Deploying the Azure OpenAI API Simulator
-To document [Running and Deploying the Azure OpenAI API Simulator](./docs/running-deploying.md) includes instructions on running the Azure OpenAI API Simulator locally, packaging and deploying it in a Docker container, and also deploying the Azure OpenAI API Simulator to Azure Container Apps.
+The document [Running and Deploying the Azure OpenAI API Simulator](./docs/running-deploying.md) includes instructions on running the Azure OpenAI API Simulator locally, packaging and deploying it in a Docker container, and also deploying the Azure OpenAI API Simulator to Azure Container Apps.
 
 ### Configuring the Azure OpenAI API Simulator
 The behavious of the Azure OpenAI API Simulator is controlled via a range of [Azure OpenAI API Simulator Configuration Options](./docs/config.md).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The document [Running and Deploying the Azure OpenAI API Simulator](./docs/runni
 The behaviour of the Azure OpenAI API Simulator is controlled via a range of [Azure OpenAI API Simulator Configuration Options](./docs/config.md).
 
 ### Extending the Azure OpenAI API Simulator
-There are also a number of [Azure OpenAI API Simulator Extensions](./docs/extensions.md) that allow you to customise the behaviour of the Azure OpenAI API Simulator. Extensions can be used to modify the request/response, add latency, or even generate responses.
+There are also a number of [Azure OpenAI API Simulator Extension points](./docs/extensions.md) that allow you to customise the behaviour of the Azure OpenAI API Simulator. Extensions can be used to modify the request/response, add latency, or even generate responses.
 
 ### Contributing to the Azure OpenAI API Simulator
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Azure OpenAI API Simulator is not a replacement for testing against the real
 The document [Running and Deploying the Azure OpenAI API Simulator](./docs/running-deploying.md) includes instructions on running the Azure OpenAI API Simulator locally, packaging and deploying it in a Docker container, and also deploying the Azure OpenAI API Simulator to Azure Container Apps.
 
 ### Configuring the Azure OpenAI API Simulator
-The behavious of the Azure OpenAI API Simulator is controlled via a range of [Azure OpenAI API Simulator Configuration Options](./docs/config.md).
+The behaviour of the Azure OpenAI API Simulator is controlled via a range of [Azure OpenAI API Simulator Configuration Options](./docs/config.md).
 
 ### Extending the Azure OpenAI API Simulator
 There are also a number of [Azure OpenAI API Simulator Extensions](./docs/extensions.md) that allow you to customise the behaviour of the Azure OpenAI API Simulator. Extensions can be used to modify the request/response, add latency, or even generate responses.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -2,7 +2,7 @@
 
 This file contains notes for anyone contributing and developing the Azure OpenAI API Simulator.
 
-The simplest way to work with and develop the simulator code is within a [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
+The simplest way to work with and develop the simulator code is within a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
 
 The repo contains Dev Container configuration that will sets up a container and install all of the dependencies needed to develop the simulator.
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,41 +1,66 @@
-# Developing the API Simulator
+# Contributing to the Azure OpenAI API Simulator
 
-This file contains some notes about developing the API simulator.
+This file contains notes for anyone contributing and developing the Azure OpenAI API Simulator.
 
-The simplest way to work with the simulator code is with [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
-The repo contains a Dev Container configuration that sets up a container with all the dependencies needed to develop the simulator.
+The simplest way to work with and develop the simulator code is within a [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
+
+The repo contains Dev Container configuration that will sets up a container and install all of the dependencies needed to develop the simulator.
+
+The rest of this document assumes that you are working within a Dev Container, though many of the instructions will work outside of a container too.
 
 ## Repo Contents
 
-- `infra` contains the bicep files to deploy the simulator to Azure Container Apps
-- `src` contains the simulator code and tests
-- `scripts` contains scripts to help with development/deployment
-- `test-aoai.http` contains a collection of HTTP requests that can be run in VS Code using the REST Client extension
+The top level repo is structured as follows:
+```
+.
+├── docs            # Markdown documentation (such as this file)
+├── examples        # contains examples of how the similator might be used
+├── infra           # contains the bicep files to deploy the simulator to Azure Container Apps
+├── loadtest        # locust-based load tests for validating the simulator performance
+├── scripts         # scripts to help with development/deployment (mostly bash scripts, called from `Makefile`)
+├── src             # the Azure OpenAI API Simulator code
+├── tests           # tests for the Azure OpenAI API Simulator
+└── tools           # test client and other tools
+```
+The `src` directory contains the main code for the simulator.
 
-Under the `src` folder ther are the following subfolders:
-- `aoai_api_simulator` - the simulator code
-- `examples` - example code showing how to extend the simulator
-- `loadtest` - locust-based load tests for validating the simulator performance
-- `test-client` -  a simple client that can be used to test the simulator interactively
-- `test-client-web` -  a simple web client that can be used to demo the chat completions
-- `tests` - integration tests for validating the simulator
+## The Makefile
 
-## Running the linter/tests
+Almost all of the common tasks for running or testing the simulator are available via the `Makefile`.
 
-There is a `Makefile` in the root of the repo that contains some useful commands.
+The following section of this document describes some of the more commonly used rules:
 
-To run the linter run `make lint`.
+Make command                     | Description
+---------------------------------|-----------------------------------------
+`make help`                      | Show the help message with a full set of available rules
+`make install-requirements`      | Installs the PyPI requirements
+`make run-simulated-api`         | Launches the AOAI Simulated API locally
+`make test`                      | Run the suite of PyTest tests (in verbose mode)
+`make lint`                      | Lints the aoai-api-simulator source code
+`make deploy-aca`                | Runs the deployment scripts for Azure Container Apps
 
-To run the tests run `make test`.
+For a full set of rules, type `make help` from the command line and you will be presented with a list of available rules.
 
-## Pre-release checklist
+## Creating Pull Requests against the Azure OpenAI API Simulator
+    
+When creating a pull request, please ensure that you have run the linter and tests locally before pushing your changes.
 
-- Ensure that the tests run
-- Compare the linter output to the last release - this helps to avoid accumulating a build-up of linting issues
+To run the linter run `make lint`. Ensure that you are not adding additional linting issues.
+
+To run the tests run `make test`. Make sure that the test suite runs successfully.
+
+## Creating a Release of the Azure OpenAI API Simulator
+
+### Pre-release checklist
+
+Before creating a new release, please ensure you have run through the following steps:
+
+- Ensure that the tests run successfully
+- Compare the linter output to the last release, and ensure that no additional linting issues have been created - this helps to avoid accumulating a build-up of linting issues
 - Deploy the simulator to Container Apps
 - Run load tests against the deployed simulator (see [Load tests](#load-tests))
 
-### Load tests
+### Load Tests
 
 The following load tests should be run against the simulator before a release:
 
@@ -45,7 +70,6 @@ To run this test, run `./scripts/run-load-test-base-latency.sh`.
 
 The test sends requests to the simulator as fast as possible with no latency and no rate limiting.
 This test is useful for validating the base latency and understanding the maximum throughput of the simulator.
-
 
 #### Load test: Added latency (1s latency, no limits)
 
@@ -63,7 +87,6 @@ This equates to 600 requests per minute or 10 requests per second.
 
 This test uses 30 test users (i.e. ~30RPS) with a `max_tokens` value of 10 for each request.
 By keeping the `max_tokens` value low, we should trigger the request-based rate limiting rather than the token-based limiting.
-
 
 #### Load test: Token limiting (no added latency, 100,000 tokens per minute)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,6 +1,6 @@
-# Extending the simulator
+# Extending the Azure OpenAI API Simulator
 
-- [Extending the simulator](#extending-the-simulator)
+- [Extending the Azure OpenAI API Simulator](#extending-the-azure-openai-api-simulator)
   - [Running with an extension](#running-with-an-extension)
   - [Creating a custom forwarder extension](#creating-a-custom-forwarder-extension)
     - [Creating a custom generator extension](#creating-a-custom-generator-extension)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,20 +1,18 @@
-# API Metrics
+# Azure OpenAI API Simulator Metrics
 
 To help you understand how the API Simulator is performing, we provide a number of metrics that you can use to monitor the simulator.
 
-- [API Metrics](#api-metrics)
-	- [aoai-api-simulator.latency.base](#aoai-api-simulatorlatencybase)
-	- [aoai-api-simulator.latency.full](#aoai-api-simulatorlatencyfull)
-	- [aoai-api-simulator.tokens.used](#aoai-api-simulatortokensused)
-	- [aoai-api-simulator.tokens.requested](#aoai-api-simulatortokensrequested)
-	- [aoai-api-simulator.tokens.rate-limit](#aoai-api-simulatortokensrate-limit)
-	- [aoai-api-simulator.limits](#aoai-api-simulatorlimits)
-
+- [Azure OpenAI API Simulator Metrics](#azure-openai-api-simulator-metrics)
+  - [aoai-api-simulator.latency.base](#aoai-api-simulatorlatencybase)
+  - [aoai-api-simulator.latency.full](#aoai-api-simulatorlatencyfull)
+  - [aoai-api-simulator.tokens.used](#aoai-api-simulatortokensused)
+  - [aoai-api-simulator.tokens.requested](#aoai-api-simulatortokensrequested)
+  - [aoai-api-simulator.tokens.rate-limit](#aoai-api-simulatortokensrate-limit)
+  - [aoai-api-simulator.limits](#aoai-api-simulatorlimits)
 
 ## aoai-api-simulator.latency.base
 
 Units: `seconds`
-
 
 The `aoai-api-simulator.latency.base` metric measures the base latency of the simulator. This is the time taken to process a request _excluding_ any added latency.
 

--- a/docs/running-deploying.md
+++ b/docs/running-deploying.md
@@ -15,7 +15,7 @@
 
 ## Getting Started
 
-The simplest way to work with and the simulator code is within a [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
+The simplest way to work with and the simulator code is within a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
 
 The repo contains Dev Container configuration that will sets up a container and install all of the dependencies needed to develop the simulator.
 

--- a/docs/running-deploying.md
+++ b/docs/running-deploying.md
@@ -1,20 +1,62 @@
-# Running and Deploying the simulator
+# Running and Deploying the Azure OpenAI API Simulator
 
-- [Running and Deploying the simulator](#running-and-deploying-the-simulator)
+- [Running and Deploying the Azure OpenAI API Simulator](#running-and-deploying-the-azure-openai-api-simulator)
   - [Getting Started](#getting-started)
+  - [Running the Simulator Locally](#running-the-simulator-locally)
+  - [Changing the Simulator Mode](#changing-the-simulator-mode)
   - [Running in Docker](#running-in-docker)
   - [Deploying to Azure Container Apps](#deploying-to-azure-container-apps)
-  - [Using the simulator with restricted network access](#using-the-simulator-with-restricted-network-access)
+  - [Using the Simulator with Restricted Network Access](#using-the-simulator-with-restricted-network-access)
     - [Unrestricted Network Access](#unrestricted-network-access)
     - [Semi-Restricted Network Access](#semi-restricted-network-access)
     - [Restricted Network Access](#restricted-network-access)
+  - [Managing Large Recordings](#managing-large-recordings)
 
 
 ## Getting Started
 
-This repo is configured with a Visual Studio Code [dev container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) that sets up a Python environment ready to work in.
+The simplest way to work with and the simulator code is within a [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
 
-After cloning the repo, install dependencies using `make install-requirements`.
+The repo contains Dev Container configuration that will sets up a container and install all of the dependencies needed to develop the simulator.
+
+This repo is configured with a Visual Studio Code [dev container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) that sets up a Python environment ready to work in, and will install the Pythong PyPI dependencies.
+
+If you are not using a Dev Container then, after cloning the repo, you can install the Python dependencies using:
+
+``` console
+make install-requirements
+```
+
+## Running the Simulator Locally
+
+Before running the Azure OpenAI API Simulator you should ensure that you have set up your local config. See [Azure OpenAI API Simulator Configuration Options](./docs/config.md) for details on how to do this.
+
+To run the simulated API, use the following command from the repository root directory:
+
+``` console
+make run-simulated-api
+```
+
+## Changing the Simulator Mode
+
+The `SIMULATOR_MODE` environment variable determines how the simulator behaves. You can either set this environment variable in the shell before running the simulator, or you can set it in the `.env` file.
+
+For example, to use the API in record/replay mode:
+
+```bash
+# Run the API in record mode
+SIMULATOR_MODE=record AZURE_OPENAI_ENDPOINT=https://mysvc.openai.azure.com/ AZURE_OPENAI_KEY=your-api-key make run-simulated-api
+
+# Run the API in replay mode
+SIMULATOR_MODE=replay make run-simulated-api
+```
+
+To run the API in generator mode, you can set the `SIMULATOR_MODE` environment variable to `generate` and run the API as above.
+
+```bash
+# Run the API in generator mode
+SIMULATOR_MODE=generate make run-simulated-api
+```
 
 ## Running in Docker
 
@@ -40,7 +82,7 @@ If no value is specified for `RECORDING_DIR`, the simulator will use `/mnt/simul
 The file share can also be used for setting the OpenAI deployment configuration or for any forwarder/generator config.
 
 
-## Using the simulator with restricted network access
+## Using the Simulator with Restricted Network Access
 
 During initialization, TikToken attempts to download an OpenAI encoding file from a public blob storage account managed by OpenAI. When running the simulator in an environment with restricted network access, this can cause the simulator to fail to start.  
   
@@ -51,6 +93,7 @@ The simulator supports three networking scenarios with different levels of acces
 - Restricted network access  
 
 Different build arguments can be used to build the simulator for each of these scenarios.
+
 ### Unrestricted Network Access  
   
 In this mode, the simulator operates normally, with TikToken downloading the OpenAI encoding file from OpenAI's public blob storage account. This scenario assumes that the Docker container can access the public internet during runtime.
@@ -62,9 +105,17 @@ The semi-restricted network access scenario applies when the build machine has a
  the simulator can be built using the Docker build argument `network_type=semi-restricted`. This will download the TikToken encoding file during the Docker image build process and cache it within the Docker image. The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
   
 ### Restricted Network Access  
+
 The restricted network access scenario applies when both the build machine and the runtime environment do not have access to the public internet. In this scenario, the simulator can be built using a pre-downloaded TikToken encoding file that must be included in a specific location. 
 
 This can be done by running the [setup_tiktoken.py](./scripts/setup_tiktoken.py) script. 
 Alternatively, you can download the [encoding file](https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken) from the public blob storage account and place it in the `src/aoai-api-simulator/tiktoken_cache` directory. Then rename the file to `9b5ad71b2ce5302211f9c61530b329a4922fc6a4`.
 
 To build the simulator in this mode, set the Docker build argument `network_type=restricted`. The simulator and the build process will then use the cached TikToken encoding file instead of retrieving it through the public internet. The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
+
+## Managing Large Recordings
+
+By default, the simulator saves the recording file after each new recorded request in `record` mode.
+If you need to create a large recording, you may want to turn off the autosave feature to improve performance.
+
+With autosave off, you can save the recording manually by sending a `POST` request to `/++/save-recordings` to save the recordings files once you have made all the requests you want to capture. You can do this using ` curl localhost:8000/++/save-recordings -X POST`. 


### PR DESCRIPTION
This PR performs some tidy up of the docs, updates some stuff that was out of date, and attempts to make the docs "flow" more naturally for anyone picking up the repo for the first time.

There's more that could be done here, but the things that have changed include:

1. Add some additional context setting and explanation to the README
2. Add a structured "how to get started" to the README
3. Use the name "Azure OpenAI API Simulator" more often (and especially in doc titles)
4. Remove info about "running the simulator" from `config.md` and move that into `running-deploying.md`
5. Expand on how to work with .env file in `config.md`
6. Enhance `developing.md` to describe the main `make` rules, and fix up the description of the folders (it was out of date)
7. Minor changes (title) to `extending.md`
8. Add instructions on running locally to `running-deploying.md` and include notes about the mode that were previously in `config.md`

I'm sure there are other enhancements to be made, but I feel this is a good start and will help people onboard to the project.

Addresses #23 