### PR TITLE
Reorder Makefile Rules.  Closes #25.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ run-test-client-simulator-local: ## Run the test client against local AOAI Simul
 run-test-client-simulator-aca: ## Run the test client against an Azure Container Apps deployment
 	./scripts/run-test-client-aca.sh
 
-run-test-client-web: ## Launch the test client web app locally
+run-test-client-web: ## Launch the test client web app locally
 	cd tools/test-client-web && \
 	flask run --host 0.0.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ install-requirements: ## Install PyPI requirements for all projects
 	pip install -r tools/test-client/requirements.txt
 	pip install -r tools/test-client-web/requirements.txt
 
-erase-recording: ## Erase all *.recording files
-	rm -rf "${makefile_dir}.recording"
-
 run-simulated-api: ## Launch the AOAI Simulated API locally
 	gunicorn \
 		aoai_api_simulator.main:app \
@@ -28,6 +25,21 @@ run-simulated-api: ## Launch the AOAI Simulated API locally
 		--workers 1 \
 		--bind 0.0.0.0:8000 \
 		--timeout 3600
+
+deploy-aca: ## Run deployment script for Azure Container Apps
+	./scripts/deploy-aca.sh
+
+test: ## Run PyTest (verbose)
+	pytest ./tests -v
+	
+test-not-slow: ## Run PyTest (verbose, skip slow tests)
+	pytest ./tests -v -m "not slow"
+
+test-watch: ## Start PyTest Watch
+	ptw --clear ./tests
+
+lint: ## Lint aoai-api-simulator source code
+	pylint ./src/aoai-api-simulator/
 
 run-test-client: ## Run the test client
 	cd tools/test-client && \
@@ -67,22 +79,10 @@ docker-run-simulated-api: ## Run the AOAI Simulated API docker container
 		-e AZURE_OPENAI_DEPLOYMENT \
 		aoai-api-simulator
 
-test: ## Run PyTest (verbose)
-	pytest ./tests -v
-
-test-not-slow: ## Run PyTest (verbose, skip slow tests)
-	pytest ./tests -v -m "not slow"
-
-test-watch: ## Start PyTest Watch
-	ptw --clear ./tests
-
-lint: ## Lint aoai-api-simulator source code
-	pylint ./src/aoai-api-simulator/
-
-deploy-aca: ## Run deployment script for Azure Container Apps
-	./scripts/deploy-aca.sh
-
 docker-build-load-test: ## Build the AOAI Simulated API Load Test as a docker image
 	# TODO should set a tag!
 	cd loadtest && \
 	docker build -t aoai-api-simulator-load-test .
+
+erase-recording: ## Erase all *.recording files
+	rm -rf "${makefile_dir}.recording"


### PR DESCRIPTION
This closes #25, my suggestion to reorder the Makefile.

`help`, `install-requirements`, `run-simulated-api`, and `deploy-aca` are now at the top as they are likely to be the rules run by most new-comers to the project.

The result of this reorder is shown via `make help` as follows...

``` console
$ make help
help                             Show this help
install-requirements             Install PyPI requirements for all projects
run-simulated-api                Launch the AOAI Simulated API locally
deploy-aca                       Run deployment script for Azure Container Apps
test                             Run PyTest (verbose)
test-not-slow                    Run PyTest (verbose, skip slow tests)
test-watch                       Start PyTest Watch
lint                             Lint aoai-api-simulator source code
run-test-client                  Run the test client
run-test-client-simulator-local  Run the test client against local AOAI Simulated API 
run-test-client-simulator-aca    Run the test client against an Azure Container Apps deployment
docker-build-simulated-api       Build the AOAI Simulated API as a docker image
docker-run-simulated-api         Run the AOAI Simulated API docker container
docker-build-load-test           Build the AOAI Simulated API Load Test as a docker image
erase-recording                  Erase all *.recording files
```