### PR TITLE
Workaround to Deployment Issue 

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -166,7 +166,8 @@ resource azureOpenAIKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: vault
   name: 'azure-openai-key'
   properties: {
-    value: azureOpenAIKey
+    // workaround to deployment issue https://github.com/microsoft/aoai-api-simulator/issues/28
+    value: empty(azureOpenAIKey) ? 'place-holder-API-key' : azureOpenAIKey
   }
 }
 resource appInsightsConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {


### PR DESCRIPTION
Closes #28.

This puts a placeholder secret into KV so that the Azure Container App doesn't get upset during deployment.

For some reason the ACA raises an error during deployment if this secret is empty. When the secret has a value, deployment is fine. Given that this particular secret is option (only used when the simulator is in record mode) then the placeholder value is needed.
