### PR TITLE
Add Test Client Docs and Enhance Other Docs. Closes #23.

### DIFF
--- a/docs/running-deploying.md
+++ b/docs/running-deploying.md
@@ -4,8 +4,10 @@
   - [Getting Started](#getting-started)
   - [Running the Simulator Locally](#running-the-simulator-locally)
   - [Changing the Simulator Mode](#changing-the-simulator-mode)
-  - [Running in Docker](#running-in-docker)
   - [Deploying to Azure Container Apps](#deploying-to-azure-container-apps)
+  - [Running in Docker](#running-in-docker)
+    - [Example: Running Container in Record Mode](#example-running-container-in-record-mode)
+    - [Example: Running Container in Replay Mode](#example-running-container-in-replay-mode)
   - [Using the Simulator with Restricted Network Access](#using-the-simulator-with-restricted-network-access)
     - [Unrestricted Network Access](#unrestricted-network-access)
     - [Semi-Restricted Network Access](#semi-restricted-network-access)
@@ -15,13 +17,11 @@
 
 ## Getting Started
 
-The simplest way to work with and the simulator code is within a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
+The simplest way to work with the simulator code is from within a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) in VS Code.
 
-The repo contains Dev Container configuration that will sets up a container and install all of the dependencies needed to develop the simulator.
+This repo contains Dev Container configuration that will set up a Dev Container and install all of the dependencies needed to develop the simulator, including the Python environment and dependencies. 
 
-This repo is configured with a Visual Studio Code [dev container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) that sets up a Python environment ready to work in, and will install the Pythong PyPI dependencies.
-
-If you are not using a Dev Container then, after cloning the repo, you can install the Python dependencies using:
+Most of this documentation will assume that you are using a Dev Container, but it is possible to work outside of a Dev Container as well. If you are not using a Dev Container then, after cloning the repo, you can install the Python dependencies using:
 
 ``` console
 make install-requirements
@@ -58,64 +58,125 @@ To run the API in generator mode, you can set the `SIMULATOR_MODE` environment v
 SIMULATOR_MODE=generate make run-simulated-api
 ```
 
-## Running in Docker
-
-If you want to run the API simulator as a Docker container, there is a `Dockerfile` that can be used to build the image.
-
-To build the image, run `docker build -t aoai-api-simulator .` from the `src/aoai-api-simulator` folder.
-
-Once the image is built, you can run is using `docker run -p 8000:8000 -e SIMULATOR_MODE=record -e AZURE_OPENAI_ENDPOINT=https://mysvc.openai.azure.com/ -e AZURE_OPENAI_KEY=your-api-key aoai-api-simulator`.
-
-Note that you can set any of the environment variable listed in the [Getting Started](#getting-started) section when running the container.
-For example, if you have the recordings on your host (in `/some/path`) , you can mount that directory into the container using the `-v` flag: `docker run -p 8000:8000 -e SIMULATOR_MODE=replay -e RECORDING_DIR=/recording -v /some/path:/recording aoai-api-simulator`.
-
 ## Deploying to Azure Container Apps
 
-The simulated API can be deployed to Azure Container Apps (ACA) to provide a publicly accessible endpoint for testing with the rest of your system:
+The simulated API can be deployed to Azure Container Apps (ACA) to provide a publicly accessible endpoint for testing with the rest of your system.
 
-Before deploying, set up a `.env` file. See the `sample.env` file for a starting point and add any configuration variables.
-Once you have your `.env` file, run `make deploy-aca`. This will deploy a container registry, build and push the simulator image to it, and deploy an Azure Container App running the simulator with the settings from `.env`.
+Before deploying, set up a `.env` file. See [Azure OpenAI API Simulator Configuration Options](./docs/config.md) for details on how to do this.
+
+Once you have your `.env` file, you can deploy to Azure using the following command:
+
+``` console
+make deploy-aca
+```
+
+This will deploy a container registry, build and push the simulator image to it, and deploy an Azure Container App running the simulator with the settings from `.env`.
 
 The ACA deployment also creates an Azure Storage account with a file share. This file share is mounted into the simulator container as `/mnt/simulator`.
+
 If no value is specified for `RECORDING_DIR`, the simulator will use `/mnt/simulator/recording` as the recording directory.
 
 The file share can also be used for setting the OpenAI deployment configuration or for any forwarder/generator config.
 
+## Running in Docker
+
+If you want to run the API simulator as a Docker container, there is a `Dockerfile` that can be used to build the image.
+
+To build the Docker image, run the following command from the repository root directory:
+
+``` console
+make docker-build-simulated-api
+```
+
+Once the image is built, you can run this container using the following command:
+
+``` console
+make docker-run-simulated-api
+```
+
+This make rule will pick up the .env file and pass the environment variables to the container. It will also mount a volume such that recordings from the simulator are written to a `.recording` folde off of the repository root. Review the `Makefile` for more details.
+
+If you want to run the docker container with different environment variables, you can do so. Some examples of this are given below:
+
+### Example: Running Container in Record Mode
+
+``` console
+docker run -p 8000:8000 \
+    -e SIMULATOR_MODE=record \
+    -e AZURE_OPENAI_ENDPOINT=https://mysvc.openai.azure.com/ \
+    -e AZURE_OPENAI_KEY=your-api-key aoai-api-simulator
+```
+
+### Example: Running Container in Replay Mode
+
+This assumes you have some recordings in folder `/my_folder/my_recordings`.
+
+``` console
+docker run -p 8000:8000 \
+    -e SIMULATOR_MODE=replay \
+    -e RECORDING_DIR=/recording \
+    -v /my_folder/my_recordings:/recording \
+    aoai-api-simulator
+```
 
 ## Using the Simulator with Restricted Network Access
 
-During initialization, TikToken attempts to download an OpenAI encoding file from a public blob storage account managed by OpenAI. When running the simulator in an environment with restricted network access, this can cause the simulator to fail to start.  
+If you intend to run the Azure OpenAI API Simulator in an environment where there are restrictions to the public internet (e.g. behind a firewall) then this section of the docs explains how to build and configure the simulator to work in such an environment.
+
+During initialization, the TikToken python package will attempt to download an OpenAI encoding file. It downloads thos file from a public blob storage account managed by OpenAI. 
+
+When running the simulator in an environment with restricted network access, this can cause the simulator to fail to start. 
   
 The simulator supports three networking scenarios with different levels of access to the public internet:  
   
-- Unrestricted network access  
-- Semi-restricted network access  
-- Restricted network access  
+- Unrestricted network access (full access to public internet)
+- Semi-restricted network access (build machine has public access, but runtime envinronment does not)  
+- Restricted network access (no access to public internet)
 
-Different build arguments can be used to build the simulator for each of these scenarios.
+These modes are described in more detail below.
 
 ### Unrestricted Network Access  
-  
-In this mode, the simulator operates normally, with TikToken downloading the OpenAI encoding file from OpenAI's public blob storage account. This scenario assumes that the Docker container can access the public internet during runtime.
-This is the default build mode.
+
+In this mode, the simulator operates normally, with TikToken downloading the OpenAI encoding file from OpenAI's public blob storage account. 
+
+This scenario assumes that the Docker container can access the public internet from the runtime environment. This is the default build mode.
   
 ### Semi-Restricted Network Access  
   
-The semi-restricted network access scenario applies when the build machine has access to the public internet but the runtime environment does not. In this scenario,
- the simulator can be built using the Docker build argument `network_type=semi-restricted`. This will download the TikToken encoding file during the Docker image build process and cache it within the Docker image. The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
+The semi-restricted network access scenario applies when the build machine has access to the public internet but the runtime environment does not. 
+
+In this scenario, the simulator can be built using the Docker build argument `network_type=semi-restricted`. 
+
+This will download the TikToken encoding file during the Docker image build process and cache it within the Docker image. 
+
+The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
   
 ### Restricted Network Access  
 
-The restricted network access scenario applies when both the build machine and the runtime environment do not have access to the public internet. In this scenario, the simulator can be built using a pre-downloaded TikToken encoding file that must be included in a specific location. 
+The restricted network access scenario applies when both the build machine and the runtime environment do not have access to the public internet. 
 
-This can be done by running the [setup_tiktoken.py](./scripts/setup_tiktoken.py) script. 
+In this scenario, the simulator can be built using a pre-downloaded TikToken encoding file that must be included in a specific location. 
+
+This can be done by running the [setup_tiktoken.py](./scripts/setup_tiktoken.py) script.
+
 Alternatively, you can download the [encoding file](https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken) from the public blob storage account and place it in the `src/aoai-api-simulator/tiktoken_cache` directory. Then rename the file to `9b5ad71b2ce5302211f9c61530b329a4922fc6a4`.
 
-To build the simulator in this mode, set the Docker build argument `network_type=restricted`. The simulator and the build process will then use the cached TikToken encoding file instead of retrieving it through the public internet. The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
+To build the simulator in this mode, set the Docker build argument `network_type=restricted`. 
+
+The simulator and the build process will then use the cached TikToken encoding file instead of retrieving it through the public internet. 
+
+The build process will also set the required `TIKTOKEN_CACHE_DIR` environment variable to point to the cached TikToken encoding file. 
 
 ## Managing Large Recordings
 
 By default, the simulator saves the recording file after each new recorded request in `record` mode.
+
 If you need to create a large recording, you may want to turn off the autosave feature to improve performance.
 
-With autosave off, you can save the recording manually by sending a `POST` request to `/++/save-recordings` to save the recordings files once you have made all the requests you want to capture. You can do this using ` curl localhost:8000/++/save-recordings -X POST`. 
+With autosave off, you can save the recording manually by sending a `POST` request to `/++/save-recordings` to save the recordings files once you have made all the requests you want to capture. 
+
+You can do this using the following command:
+
+``` console
+curl localhost:8000/++/save-recordings -X POST
+```

--- a/docs/running-deploying.md
+++ b/docs/running-deploying.md
@@ -94,7 +94,7 @@ Once the image is built, you can run this container using the following command:
 make docker-run-simulated-api
 ```
 
-This make rule will pick up the .env file and pass the environment variables to the container. It will also mount a volume such that recordings from the simulator are written to a `.recording` folde off of the repository root. Review the `Makefile` for more details.
+This make rule will pick up the .env file and pass the environment variables to the container. It will also mount a volume such that recordings from the simulator are written to a `.recording` folder off of the repository root. Review the `Makefile` for more details.
 
 If you want to run the docker container with different environment variables, you can do so. Some examples of this are given below:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,12 +4,78 @@
 
 The Azure OpenAI API Simulator is designed to sit between an app that uses Azure OpenAI, and the Azure OpenAI API itself.
 
-However, if you're helping to develop the simulator, testing its functionality, or you're just curious about how it works, you may not have an app that uses Azure OpenAI to test with. For this reason there are two test clients within this repo that you can use to test the simulator.
+However, if you're helping to develop the simulator, testing its functionality, or you're just curious about how it works, you may not have an app that uses Azure OpenAI API. 
+
+For this reason there are a set of sample test clients within this repo that you can use to test the simulator, or simply use to call the Azure OpenAI API directly.
 
 Folder | Description
 --- | ---
 `./tools/test-client` | A Python script that sends requests to an OpenAI API end point and displays the responses.
 `./tools/test-client-web` | A web-based client that sends requests to an OpenAI API end point, and allows for more ad-hoc user interactions with that API.
 
-Both of these test clients are bare-bones implementations of apps that use OpenAI, and are not intended to be used in production. They are intended to be used for testing and development purposes only.
+Both of these test clients are bare-bones implementations of apps that use OpenAI, and are not intended to be used in production. They are sample code. They are intended to be used for testing and development purposes only. The following describes how these samples can be used.
 
+### Test-Client
+
+The `test-client` is a single Python script that will make called to an Azure OpenAI API endpoint, regardless of whether this is a similated API or the real API. To fully understand what this script does it it best to open the `./tools/test-client/app.py` file and read through the code. The following description provides a high-level overview of how to use this script.
+
+You can run this script from the command line using the following `make` command:
+
+``` console
+make run-test-client
+```
+
+When you run this command it will launch the `test-client` script, and will use the configuration defined in your `.env` file.
+
+#### Test-Client MODE
+
+The Test-Client uses a `MODE` environment variable to determine exactly what sort of OpenAI API call it should make. The following table describes the various values you can specify:
+
+`MODE` | Description
+--- | ---
+completion | Tests the completion API
+chat | Test the chat completion API with a single chat turn
+chatbot | Allows you to interact with the chat completion API using multiple chat turns
+chatbot-stream | Allows you to interact the streaming chat completion API, using multiple chat turns
+embedding | Tests the embedding API
+doc-intelligence | Tests the document intelligence API
+
+If you don't specify `MODE` then script will assume `completion`. 
+
+You can set this `MODE` environment variable via the command line. 
+
+``` console
+MODE=chat make run-test-client
+```
+
+### Running the Test-Client against a local Azure OpenAI API Simulator
+
+If you're running the Azure OpenAI API Simulator locally (either directly, or as a Docker container) there is a convinient `make` rule for this scenario:
+
+``` console
+MODE=chat make run-test-client-simulator-local
+```
+
+This will run the same Python script, but will set things up so that the test-client uses localhost endpoints (see `Makefile` for details).
+
+### Running the Test-Client against an Azure Container Application Deployment
+
+If you have already deployed the Azure OpenAI API Simulator to an Azure Container Application, you can run the test-client against that deployment using the following `make` command:
+
+``` console
+make run-test-client-simulator-aca
+```
+
+This will pick up the details of your deployment from the `./infra/output.json` file that this deployment will have created, and will then run the test client against the deployed simulator.
+
+For more information on deploying the simulator, refer to the [Running and Deploying the Azure OpenAI API Simulator](./running-deploying.md) documentation.
+
+### Test-Client-Web
+
+The `test-client-web` folder contains a simple web app that will allow you to interact with either the Azure OpenAI API Simulator, or the real Azure OpenAI API.
+
+To launch this web app, use the following `make` command:
+
+``` console
+make run-test-client-web
+```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,15 @@
+# Tools
+
+## Test Clients
+
+The Azure OpenAI API Simulator is designed to sit between an app that uses Azure OpenAI, and the Azure OpenAI API itself.
+
+However, if you're helping to develop the simulator, testing its functionality, or you're just curious about how it works, you may not have an app that uses Azure OpenAI to test with. For this reason there are two test clients within this repo that you can use to test the simulator.
+
+Folder | Description
+--- | ---
+`./tools/test-client` | A Python script that sends requests to an OpenAI API end point and displays the responses.
+`./tools/test-client-web` | A web-based client that sends requests to an OpenAI API end point, and allows for more ad-hoc user interactions with that API.
+
+Both of these test clients are bare-bones implementations of apps that use OpenAI, and are not intended to be used in production. They are intended to be used for testing and development purposes only.
+

--- a/tools/test-client/app.py
+++ b/tools/test-client/app.py
@@ -16,6 +16,8 @@ mode = os.getenv("MODE")
 if mode is None:
     print(f"MODE is not set - defaulting to completion. Options are {mode_options}")
     mode = "completion"
+else:
+    print(f"MODE is set to {mode}")
 
 
 if mode in aoai_modes:


### PR DESCRIPTION
This PR adds docs for the test-client folder.
It also enhances the running/deploying docs.

This covers most of the major `Makefile` commands, and as such, this closes #23 