### PR TITLE
Minor enhancements to the chat completion test app

### DIFF
--- a/tools/test-client-web/templates/index.html
+++ b/tools/test-client-web/templates/index.html
@@ -50,6 +50,7 @@
 			if (messages.length > 1) { // 1 because we just pushed the user message
 				output.textContent += `\n---\n`;
 			}
+
 			output.textContent += `You: ${inputText}\n`;
 			input.value = '';
 
@@ -78,21 +79,24 @@
 
 <body>
 	<h1>Chat completion test app 🤖</h1>
-	<div class="section">
-		Target endpoint:
-		<select>
-			<option value="live">Azure OpenAI</option>
-			<option value="simulator">OpenAI Simulator</option>
-		</select>
-		<button id="clear" onclick="clearMessages()">Clear</button>
-	</div>
-	<div class="section">
-		<textarea id="output" readonly></textarea>
-	</div>
-	<div class="section">
-		Enter your message:<input id="input" type="text">
-		<button id="send-message" onclick="sendMessage()">Send</button>
-	</div>
+	<form onsubmit="sendMessage(); return false">
+		<div class="section">
+			Target endpoint:
+			<select id="endpoint">
+				<option value="live">Azure OpenAI</option>
+				<option value="simulator">OpenAI Simulator</option>
+			</select>
+			<button id="clear" type="button" onclick="clearMessages(); return false">Clear</button>
+		</div>
+		<div class="section">
+			<textarea id="output" readonly></textarea>
+		</div>
+		<div class="section">
+			<label for="input">Enter your message:</label>
+			<input id="input" type="text" autofocus required>
+			<button id="send-message" type="submit">Send</button>
+		</div>
+	<form>
 </body>
 
 </html>


### PR DESCRIPTION
Made a few minor enhancements to the chat completion test app:

* Updated the markup to leverage a form tag
* Pressing `enter` after typing input will send the request (same as clicking the `send` button)
* Automatically set focus to the input textbox on page load