### PR TITLE
Add New Env Vars for Testing. Closes #34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ run-test-client: ## Run the test client
 
 run-test-client-simulator-local: ## Run the test client against local AOAI Simulated API 
 	cd tools/test-client && \
-	AZURE_OPENAI_KEY=${SIMULATOR_API_KEY} \
-	AZURE_OPENAI_ENDPOINT=http://localhost:8000 \
-	AZURE_FORM_RECOGNIZER_ENDPOINT=http://localhost:8000 \
-	AZURE_FORM_RECOGNIZER_KEY=${SIMULATOR_API_KEY} \
+	TEST_OPENAI_KEY=${SIMULATOR_API_KEY} \
+	TEST_OPENAI_ENDPOINT=http://localhost:8000 \
+	TEST_FORM_RECOGNIZER_ENDPOINT=http://localhost:8000 \
+	TEST_FORM_RECOGNIZER_KEY=${SIMULATOR_API_KEY} \
 	python app.py
 
 run-test-client-simulator-aca: ## Run the test client against an Azure Container Apps deployment

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,25 +21,25 @@ When running the Azure OpenAI API Simulator, there are a number of environment v
 | `SIMULATOR_MODE`                | The mode the simulator should run in. Current options are `record`, `replay`, and `generate`.                                                                                     |
 | `SIMULATOR_API_KEY`             | The API key used by the simulator to authenticate requests. If not specified a key is auto-generated (see the logs). It is recommended to set a deterministic key value in `.env` |
 | `RECORDING_DIR`                 | The directory to store the recorded requests and responses (defaults to `.recording`).                                                                                            |
-| `OPENAI_DEPLOYMENT_CONFIG_PATH` | The path to a JSON file that contains the deployment configuration. See [OpenAI Rate-Limiting](#rate-limiting)                                                             |
+| `OPENAI_DEPLOYMENT_CONFIG_PATH` | The path to a JSON file that contains the deployment configuration. See [OpenAI Rate-Limiting](#configuring-rate-limiting)                                                             |
 | `ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS`| If set to `True` (default), the simulator will generate OpenAI responses for any deployment. If set to `False`, the simulator will only generate responses for known deployments. |
 | `AZURE_OPENAI_ENDPOINT`         | The endpoint for the Azure OpenAI service, e.g. `https://mysvc.openai.azure.com/`. Used by the simulator when forwarding requests.                                                                 |
 | `AZURE_OPENAI_KEY`              | The API key for the Azure OpenAI service. Used by the simulator when forwarding requests                                                                                                           |
 | `AZURE_OPENAI_DEPLOYMENT`       | The deployment name for your GPT model. Used by the simulator when forwarding requests.                                                  |
 | `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`       | The deployment name for your embedding model. Used by the simulator when forwarding requests.                                                  |
 | `LOG_LEVEL`                     | The log level for the simulator. Defaults to `INFO`.                                                                                                                              |
-| `LATENCY_OPENAI_*`              | The latency to add to the OpenAI service when using generated output. See [Latency](#latency) for more details.                                                                   |
-| `RECORDING_AUTOSAVE`            | If set to `True` (default), the simulator will save the recording after each request (see [Large Recordings](#large-recordings)).                                                 |
+| `LATENCY_OPENAI_*`              | The latency to add to the OpenAI service when using generated output. See [Latency](#configuring-latency) for more details.                                                                   |
+| `RECORDING_AUTOSAVE`            | If set to `True` (default), the simulator will save the recording after each request (see [Large Recordings](./running-deploying.md#managing-large-recordings)).                                                 |
 | `EXTENSION_PATH`                | The path to a Python file that contains the extension configuration. This can be a single python file or a package folder - see [Extending the simulator](./extending.md)         |
 
 There are also a set of environment variables that the test clients and tests will use. These are used to "point" the test clients at the a deployment of the simulator (local, or in Azure).
 
 | Variable                        | Description |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TEST_OPENAI_ENDPOINT` | **Used by test client code only**. Defines the OpenAI-like endpoint that the test client will call. Most likely set to the location of your similator deployment.
-| `TEST_OPENAI_KEY` | **Used by test client code. only**. Defines the key that will be set to the `TEST_OPENAI_ENDPOINT` when making requests. Most likely set to the value of `SIMULATOR_API_KEY`.
-| `TEST_OPENAI_DEPLOYMENT` | **Used by test client code only**. Defines the GPT model deployment that the test client will request.
-| `TEST_OPENAI_EMBEDDING_DEPLOYMENT` | **Used by test client code only**. Defines the embeddking model deployment that the test client will request.
+| `TEST_OPENAI_ENDPOINT` | **Used by test client code only**. Defines the OpenAI-like endpoint that the test client will call. Most likely set to the location of your similator deployment.|
+| `TEST_OPENAI_KEY` | **Used by test client code. only**. Defines the key that will be set to the `TEST_OPENAI_ENDPOINT` when making requests. Most likely set to the value of `SIMULATOR_API_KEY`.|
+| `TEST_OPENAI_DEPLOYMENT` | **Used by test client code only**. Defines the GPT model deployment that the test client will request.|
+| `TEST_OPENAI_EMBEDDING_DEPLOYMENT` | **Used by test client code only**. Defines the embeddking model deployment that the test client will request.|
 
 ### Setting Environment Variables via the `.env` File
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,14 +23,23 @@ When running the Azure OpenAI API Simulator, there are a number of environment v
 | `RECORDING_DIR`                 | The directory to store the recorded requests and responses (defaults to `.recording`).                                                                                            |
 | `OPENAI_DEPLOYMENT_CONFIG_PATH` | The path to a JSON file that contains the deployment configuration. See [OpenAI Rate-Limiting](#rate-limiting)                                                             |
 | `ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS`| If set to `True` (default), the simulator will generate OpenAI responses for any deployment. If set to `False`, the simulator will only generate responses for known deployments. |
-| `AZURE_OPENAI_ENDPOINT`         | The endpoint for the Azure OpenAI service, e.g. `https://mysvc.openai.azure.com/`. Used when forwarding requests.                                                                 |
-| `AZURE_OPENAI_KEY`              | The API key for the Azure OpenAI service. Used when forwarding requests                                                                                                           |
+| `AZURE_OPENAI_ENDPOINT`         | The endpoint for the Azure OpenAI service, e.g. `https://mysvc.openai.azure.com/`. Used by the simulator when forwarding requests.                                                                 |
+| `AZURE_OPENAI_KEY`              | The API key for the Azure OpenAI service. Used by the simulator when forwarding requests                                                                                                           |
+| `AZURE_OPENAI_DEPLOYMENT`       | The deployment name for your GPT model. Used by the simulator when forwarding requests.                                                  |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`       | The deployment name for your embedding model. Used by the simulator when forwarding requests.                                                  |
 | `LOG_LEVEL`                     | The log level for the simulator. Defaults to `INFO`.                                                                                                                              |
 | `LATENCY_OPENAI_*`              | The latency to add to the OpenAI service when using generated output. See [Latency](#latency) for more details.                                                                   |
 | `RECORDING_AUTOSAVE`            | If set to `True` (default), the simulator will save the recording after each request (see [Large Recordings](#large-recordings)).                                                 |
 | `EXTENSION_PATH`                | The path to a Python file that contains the extension configuration. This can be a single python file or a package folder - see [Extending the simulator](./extending.md)         |
-| `AZURE_OPENAI_DEPLOYMENT`       | Used by the test app to set the name of the deployed model in your Azure OpenAI service. Use a gpt-35-turbo-instruct deployment.                                                  |
 
+There are also a set of environment variables that the test clients and tests will use. These are used to "point" the test clients at the a deployment of the simulator (local, or in Azure).
+
+| Variable                        | Description |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEST_OPENAI_ENDPOINT` | **Used by test client code only**. Defines the OpenAI-like endpoint that the test client will call. Most likely set to the location of your similator deployment.
+| `TEST_OPENAI_KEY` | **Used by test client code. only**. Defines the key that will be set to the `TEST_OPENAI_ENDPOINT` when making requests. Most likely set to the value of `SIMULATOR_API_KEY`.
+| `TEST_OPENAI_DEPLOYMENT` | **Used by test client code only**. Defines the GPT model deployment that the test client will request.
+| `TEST_OPENAI_EMBEDDING_DEPLOYMENT` | **Used by test client code only**. Defines the embeddking model deployment that the test client will request.
 
 ### Setting Environment Variables via the `.env` File
 

--- a/sample.env
+++ b/sample.env
@@ -1,13 +1,35 @@
 # Create a copy of this file called .env, and ensure that all variables have valid values.
+# See config.md for the full set config variables and their descriptions
 
-# Deployment Config
-BASENAME=__CHANGE_ME___                                                         # Prefix for assets deployed into Azure
-LOCATION=__CHANGE_ME___                                                         # Azure region the assets will be deployed to 
 
-# Simulator Config. See config.md for the full set config variables
-SIMULATOR_MODE=generate                                                         # Simulator mode
-OPENAI_DEPLOYMENT_CONFIG_PATH=examples/openai_deployment_config.json            # The path to a JSON file that contains the deployment configuration
+# Deployment Config (used when deploying the simulator)
+BASENAME=__CHANGE_ME___
+LOCATION=__CHANGE_ME___
 
-#  Open Telemetry Config
-OTEL_SERVICE_NAME=aoai-api-simulator-local-dev                                  # The service name used by Open Telemetry
-OTEL_METRIC_EXPORT_INTERVAL=10000                                               # Open Telemetry metric export interval (milliseconds)
+
+# Simulator Config (used by/within the simulator)
+SIMULATOR_MODE=generate
+OPENAI_DEPLOYMENT_CONFIG_PATH=examples/openai_deployment_config.json
+SIMULATOR_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_KEY=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT=
+
+AZURE_FORM_RECOGNIZER_ENDPOINT=
+AZURE_FORM_RECOGNIZER_KEY=
+
+
+#  Open Telemetry Config (used within the simulator)
+OTEL_SERVICE_NAME=aoai-api-simulator-local-dev
+OTEL_METRIC_EXPORT_INTERVAL=10000
+
+
+# Test Client Config (used to direct the tests and test clients)
+TEST_OPENAI_ENDPOINT=
+TEST_OPENAI_KEY=
+TEST_OPENAI_DEPLOYMENT=gpt-3.5-turbo-0613
+TEST_OPENAI_EMBEDDING_DEPLOYMENT=
+
+TEST_FORM_RECOGNIZER_ENDPOINT=
+TEST_FORM_RECOGNIZER_KEY=

--- a/scripts/run-test-client-aca.sh
+++ b/scripts/run-test-client-aca.sh
@@ -8,18 +8,19 @@ if [[ -f "$script_dir/../.env" ]]; then
 	source "$script_dir/../.env"
 fi
 
-
 if [[ ! -f "$script_dir/../infra/output.json" ]]; then
   echo "output.json not found - have you deployed the base infra?"
   exit 1
 fi
 
-api_fqdn=$(jq -r .apiSimFqdn)
+api_fqdn=$(jq -r .apiSimFqdn < "$script_dir/../infra/output.json")
+
 if [[ -z "$api_fqdn" ]]; then
   echo "API endpoint (apiSimFqdn) not found in output.json"
   exit 1
 fi
 
+
 echo "== Running test-client against simulator at https://$api_fqdn"
 cd tools/test-client
-AZURE_OPENAI_KEY="${SIMULATOR_API_KEY}" AZURE_OPENAI_ENDPOINT="https://$api_fqdn" AZURE_FORM_RECOGNIZER_ENDPOINT="https://$api_fqdn" python app.py
+TEST_OPENAI_KEY="${SIMULATOR_API_KEY}" TEST_OPENAI_ENDPOINT="https://$api_fqdn" TEST_FORM_RECOGNIZER_ENDPOINT="https://$api_fqdn" python app.py

--- a/test-aoai.http
+++ b/test-aoai.http
@@ -1,12 +1,8 @@
-# Comment/uncomment to switch between Azure and local deployment
-# @aoai_endpoint={{$dotenv AZURE_OPENAI_ENDPOINT}}
-# @aoai_key={{$dotenv AZURE_OPENAI_KEY}}
 
-@aoai_endpoint=http://localhost:8000/
-@aoai_key={{$dotenv SIMULATOR_API_KEY}}
-
-@aoai_deployment={{$dotenv AZURE_OPENAI_DEPLOYMENT}}
-@aoai_embedding_deployment={{$dotenv AZURE_OPENAI_EMBEDDING_DEPLOYMENT}}
+@aoai_endpoint={{$dotenv TEST_OPENAI_ENDPOINT}}
+@aoai_key={{$dotenv TEST_OPENAI_KEY}}
+@aoai_deployment={{$dotenv TEST_OPENAI_DEPLOYMENT}}
+@aoai_embedding_deployment={{$dotenv TEST_OPENAI_EMBEDDING_DEPLOYMENT}}
 
 # https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
 

--- a/test-doc-intelligence.http
+++ b/test-doc-intelligence.http
@@ -1,9 +1,6 @@
 # Comment/uncomment to switch between Azure and local deployment
-@doc_intelligence_endpoint={{$dotenv AZURE_FORM_RECOGNIZER_ENDPOINT}}
-@doc_intelligence_key={{$dotenv AZURE_FORM_RECOGNIZER_KEY}}
-
-# @doc_intelligence_endpoint=http://localhost:8000/
-# @doc_intelligence_key={{$dotenv SIMULATOR_API_KEY}}
+@doc_intelligence_endpoint={{$dotenv TEST_FORM_RECOGNIZER_ENDPOINT}}
+@doc_intelligence_key={{$dotenv TEST_FORM_RECOGNIZER_KEY}}
 
 # https://learn.microsoft.com/en-gb/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api?view=doc-intel-3.1.0&viewFallbackFrom=form-recog-3.0.0&preserve-view=true&pivots=programming-language-rest-api
 

--- a/tools/test-client-web/app.py
+++ b/tools/test-client-web/app.py
@@ -3,22 +3,17 @@ import os
 from openai import AzureOpenAI
 from flask import Flask, request, render_template
 
-
-aoai_api_key = os.getenv("AZURE_OPENAI_KEY")
+aoai_api_key = os.getenv("TEST_OPENAI_KEY")
 if not aoai_api_key:
-    raise Exception("AZURE_OPENAI_KEY environment variable is required")
+    raise Exception("TEST_OPENAI_KEY environment variable is required")
 
-aoai_api_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+aoai_api_endpoint = os.getenv("TEST_OPENAI_ENDPOINT")
 if not aoai_api_endpoint:
-    raise Exception("AZURE_OPENAI_ENDPOINT environment variable is required")
+    raise Exception("TEST_OPENAI_ENDPOINT environment variable is required")
 
-aoai_api_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+aoai_api_deployment = os.getenv("TEST_OPENAI_DEPLOYMENT")
 if not aoai_api_deployment:
-    raise Exception("AZURE_OPENAI_DEPLOYMENT environment variable is required")
-
-simulator_api_key = os.getenv("SIMULATOR_API_KEY")
-if not simulator_api_key:
-    raise Exception("SIMULATOR_API_KEY environment variable is required")
+    raise Exception("TEST_OPENAI_DEPLOYMENT environment variable is required")
 
 app = Flask(__name__)
 app.config["TEMPLATES_AUTO_RELOAD"] = True
@@ -37,21 +32,14 @@ def foo():
 @app.route("/api/chat", methods=["POST"])
 def api_chat():
     body = request.get_json()
-    target_endpoint = body["target_endpoint"]
 
-    if target_endpoint == "live":
-        print("Sending request to live API...", flush=True)
-        aoai_client = AzureOpenAI(
-            api_key=aoai_api_key, api_version="2023-12-01-preview", azure_endpoint=aoai_api_endpoint, max_retries=0
-        )
-    else:
-        print("Sending request to simulated API...", flush=True)
-        aoai_client = AzureOpenAI(
-            api_key=simulator_api_key,
-            api_version="2023-12-01-preview",
-            azure_endpoint="http://localhost:8000",
-            max_retries=0,
-        )
+    print("Sending request to API...", flush=True)
+    aoai_client = AzureOpenAI(
+        api_key=aoai_api_key,
+        api_version="2023-12-01-preview",
+        azure_endpoint=aoai_api_endpoint,
+        max_retries=0,
+    )
 
     messages = body["messages"]
     response = aoai_client.chat.completions.create(model=aoai_api_deployment, messages=messages)

--- a/tools/test-client-web/templates/index.html
+++ b/tools/test-client-web/templates/index.html
@@ -42,8 +42,7 @@
 		}
 		function sendMessage() {
 			const input = document.getElementById('input');
-			const output = document.getElementById('output');
-			const targetEndpoint = document.querySelector('select').value;
+			const output = document.getElementById('output');			
 
 			const inputText = input.value;
 			messages.push({ "role": "user", "content": inputText });
@@ -61,8 +60,7 @@
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({
-					"messages": messages,
-					"target_endpoint": targetEndpoint
+					"messages": messages
 				})
 			})
 				.then(response => response.json())
@@ -79,24 +77,16 @@
 
 <body>
 	<h1>Chat completion test app 🤖</h1>
-	<form onsubmit="sendMessage(); return false">
-		<div class="section">
-			Target endpoint:
-			<select id="endpoint">
-				<option value="live">Azure OpenAI</option>
-				<option value="simulator">OpenAI Simulator</option>
-			</select>
-			<button id="clear" type="button" onclick="clearMessages(); return false">Clear</button>
-		</div>
-		<div class="section">
-			<textarea id="output" readonly></textarea>
-		</div>
-		<div class="section">
-			<label for="input">Enter your message:</label>
-			<input id="input" type="text" autofocus required>
-			<button id="send-message" type="submit">Send</button>
-		</div>
-	<form>
+	<div class="section">
+		<button id="clear" onclick="clearMessages()">Clear</button>
+	</div>
+	<div class="section">
+		<textarea id="output" readonly></textarea>
+	</div>
+	<div class="section">
+		Enter your message:<input id="input" type="text">
+		<button id="send-message" onclick="sendMessage()">Send</button>
+	</div>
 </body>
 
 </html>

--- a/tools/test-client/app.py
+++ b/tools/test-client/app.py
@@ -21,14 +21,14 @@ else:
 
 
 if mode in aoai_modes:
-    api_key = os.getenv("AZURE_OPENAI_KEY")
-    api_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    api_key = os.getenv("TEST_OPENAI_KEY")
+    api_endpoint = os.getenv("TEST_OPENAI_ENDPOINT")
 
     if api_key is None:
-        print("AZURE_OPENAI_KEY is not set")
+        print("TEST_OPENAI_KEY is not set")
         exit(1)
     if api_endpoint is None:
-        print("AZURE_OPENAI_ENDPOINT is not set")
+        print("TEST_OPENAI_ENDPOINT is not set")
         exit(1)
     print("Connecting to: " + api_endpoint)
     aoai_client = AzureOpenAI(
@@ -37,8 +37,8 @@ if mode in aoai_modes:
     print("")
 
 if mode == "doc-intelligence":
-    api_endpoint = os.environ["AZURE_FORM_RECOGNIZER_ENDPOINT"]
-    api_key = os.environ["AZURE_FORM_RECOGNIZER_KEY"]
+    api_endpoint = os.environ["TEST_FORM_RECOGNIZER_ENDPOINT"]
+    api_key = os.environ["TEST_FORM_RECOGNIZER_KEY"]
 
     credential = AzureKeyCredential(api_key)
     document_analysis_client = DocumentAnalysisClient(api_endpoint, credential)
@@ -46,18 +46,18 @@ if mode == "doc-intelligence":
 
 def get_deployment_name():
     # This will correspond to the custom name you chose for your deployment when you deployed a model. Use a gpt-35-turbo-instruct deployment.
-    deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+    deployment_name = os.getenv("TEST_OPENAI_DEPLOYMENT")
     if deployment_name is None:
-        print("AZURE_OPENAI_DEPLOYMENT is not set")
+        print("TEST_OPENAI_DEPLOYMENT is not set")
         exit(1)
     return deployment_name
 
 
 def get_embedding_deployment_name():
     # This will correspond to the custom name you chose for your deployment when you deployed a model. Use a gpt-35-turbo-instruct deployment.
-    deployment_name = os.getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")
+    deployment_name = os.getenv("TEST_OPENAI_EMBEDDING_DEPLOYMENT")
     if deployment_name is None:
-        print("AZURE_OPENAI_EMBEDDING_DEPLOYMENT is not set")
+        print("TEST_OPENAI_EMBEDDING_DEPLOYMENT is not set")
         exit(1)
     return deployment_name
 


### PR DESCRIPTION
As per #34, this PR adds additional env vars so that there is a clear distinction between...

1. Environment variables that are **used by the simulator** to access the Azure OpenAI "backend" are all prefixed with `AZURE_`
2. Environment variables that are **used by test clients** to call *either* the simulator or the real Azure OpenAI API are all prefixed with `TEST_`

Hence, `.env` now contains two sections.

Previously we were using the `AZURE_` env vars for both purposes. This is more explicit.

Scripts and code that used these env vars has been updated, along with docs and other supporting material.