### PR TITLE
Fix Test Discovery for VS code and Terminal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,8 @@
 		"editor.defaultFormatter": "ms-python.black-formatter"
 	},
 	"python.testing.pytestArgs": [
-		"src"
-	],
+        "tests"
+    ],
 	"python.testing.unittestEnabled": false,
 	"python.testing.pytestEnabled": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,4 @@ line-length = 120
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
+testpaths = ["./tests"]


### PR DESCRIPTION
The `settings.json` change fixes test discovery within VS Code (it wasn't finding any tests)

The 'pyproject.toml` change means that running `pytest` from the terminal will only look in the folder where tests live.