### PR TITLE
Enhance Unit Tests. Closes #33.

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,9 +168,8 @@ async def test_openai_record_replay_completion_via_config_endpoint(httpserver: H
             assert response.choices[0].text == "This is a test"
 
             # this call should fail
-            try:
+            with pytest.raises(InternalServerError) as e:
                 prompt = "This is a different prompt value and should fail as it isn't in the recording file"
                 response = aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=50)
-                assert False, "Expected request to fail for non-recorded prompt"
-            except InternalServerError as e:
-                assert e.status_code == 500
+
+            assert e.value.status_code == 500

--- a/tests/test_doc_intell_generator_example.py
+++ b/tests/test_doc_intell_generator_example.py
@@ -63,15 +63,13 @@ async def test_requires_auth():
         base_path = os.path.dirname(os.path.realpath(__file__))
         pdf_path = os.path.join(base_path, "../tools/test-client/receipt.png")
 
-        try:
+        with pytest.raises(ClientAuthenticationError) as e:
             print("Making request...")
             with open(pdf_path, "rb") as f:
                 document_analysis_client.begin_analyze_document("prebuilt-receipt", f)
 
-            assert False, "Should get exception"
-        except ClientAuthenticationError as e:
-            assert e.status_code == 401
-            assert e.message == "Operation returned an invalid status 'Unauthorized'"
+        assert e.value.status_code == 401
+        assert e.value.message == "Operation returned an invalid status 'Unauthorized'"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extension_load.py
+++ b/tests/test_extension_load.py
@@ -2,6 +2,7 @@
 Test extension loading
 """
 
+from aoai_api_simulator.record_replay.handler import get_default_forwarders
 from aoai_api_simulator.config_loader import initialize_config
 from aoai_api_simulator.generator.manager import get_default_generators
 from aoai_api_simulator.models import (
@@ -11,12 +12,12 @@ from aoai_api_simulator.models import (
     CompletionLatency,
     EmbeddingLatency,
 )
+
 import pytest
 import requests
 
 from .test_uvicorn_server import UvicornTestServer
 
-from aoai_api_simulator.record_replay.handler import get_default_forwarders
 
 API_KEY = "123456789"
 

--- a/tests/test_lorem_generation.py
+++ b/tests/test_lorem_generation.py
@@ -63,8 +63,10 @@ def run_test(max_tokens, expected_min, expected_max, max_duration, iteration_cou
         count += 1
 
         token_count = num_tokens_from_string(text, "gpt-3.5-turbo-0613")
-        assert token_count <= expected_max
-        assert token_count >= expected_min
+
+        assert token_count <= expected_max, f"{token_count=} exceeds {expected_max=}"
+        assert token_count >= expected_min, f"{token_count=} is less than {expected_min=}"
 
     avg_duration = total_time / count
-    assert avg_duration < max_duration
+
+    assert avg_duration < max_duration, f"{avg_duration=} exceeded {max_duration=}"

--- a/tests/test_lorem_generation.py
+++ b/tests/test_lorem_generation.py
@@ -42,7 +42,7 @@ def test_generation_min_max_time_10_000_tokens():
     """
     run_test(
         max_tokens=10000,
-        expected_min=9994,
+        expected_min=9993,
         expected_max=10000,
         max_duration=0.01,
     )

--- a/tests/test_openai_generator_chat_completion.py
+++ b/tests/test_openai_generator_chat_completion.py
@@ -61,12 +61,11 @@ async def test_requires_auth():
         )
         messages = [{"role": "user", "content": "What is the meaning of life?"}]
 
-        try:
+        with pytest.raises(AuthenticationError) as e:
             aoai_client.chat.completions.create(model="deployment1", messages=messages, max_tokens=50)
-            assert False, "Expected an exception"
-        except AuthenticationError as e:
-            assert e.status_code == 401
-            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
+
+        assert e.value.status_code == 401
+        assert e.value.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
 
 
 @pytest.mark.asyncio
@@ -111,12 +110,12 @@ async def test_requires_known_deployment_when_config_set():
         )
         messages = [{"role": "user", "content": "What is the meaning of life?"}]
         max_tokens = 50
-        try:
+
+        with pytest.raises(NotFoundError) as e:
             aoai_client.chat.completions.create(model="_unknown_deployment_", messages=messages, max_tokens=max_tokens)
-            assert False, "Expected 404 error"
-        except NotFoundError as e:
-            assert e.status_code == 404
-            assert e.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
+
+        assert e.value.status_code == 404
+        assert e.value.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_generator_completion.py
+++ b/tests/test_openai_generator_completion.py
@@ -61,12 +61,11 @@ async def test_requires_auth():
         )
         prompt = "This is a test prompt"
 
-        try:
+        with pytest.raises(AuthenticationError) as e:
             aoai_client.completions.create(model="deployment1", prompt=prompt, max_tokens=50)
-            assert False, "Expected an exception"
-        except AuthenticationError as e:
-            assert e.status_code == 401
-            assert e.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
+
+        assert e.value.status_code == 401
+        assert e.value.message == "Error code: 401 - {'detail': 'Missing or incorrect API Key'}"
 
 
 @pytest.mark.asyncio
@@ -109,12 +108,12 @@ async def test_requires_known_deployment_when_config_set():
         )
         prompt = "This is a test prompt"
         max_tokens = 50
-        try:
+
+        with pytest.raises(NotFoundError) as e:
             aoai_client.completions.create(model="_unknown_deployment_", prompt=prompt, max_tokens=max_tokens)
-            assert False, "Expected 404 error"
-        except NotFoundError as e:
-            assert e.status_code == 404
-            assert e.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
+
+        assert e.value.status_code == 404
+        assert e.value.message == "Error code: 404 - {'error': 'Deployment _unknown_deployment_ not found'}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_record.py
+++ b/tests/test_openai_record.py
@@ -218,13 +218,12 @@ async def test_openai_record_replay_completion_limit_reached(httpserver: HTTPSer
             assert len(response.choices) == 1
             assert response.choices[0].text == "This is a test"
 
-            try:
+            with pytest.raises(RateLimitError) as e:
                 aoai_client.completions.create(model="low_limit", prompt=prompt, max_tokens=50)
-                assert False, "Expect to be rate-limited"
-            except RateLimitError as e:
-                assert e.status_code == 429
-                # limit should be enforced based on requests (not tokens), so reset in 10s
-                assert (
-                    e.message
-                    == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
-                )
+
+            assert e.value.status_code == 429
+            # limit should be enforced based on requests (not tokens), so reset in 10s
+            assert (
+                e.value.message
+                == "Error code: 429 - {'error': {'code': '429', 'message': 'Requests to the OpenAI API Simulator have exceeded call rate limit. Please retry after 10 seconds.'}}"
+            )


### PR DESCRIPTION
This PR applys some changes to unit tests. It includes...

We have a "flakey test" that sometimes fails in CI builds. I've enhanced the messages that it produces so it's a bit clearer what's going on. In addition, we've relaxed the minimum value that the test uses for assertion (per discussion with @stuartleeks).  This closes #33.

Additionally, the use of `pytest.raises` has been introduced to replace the try/catch pattern that was previously present.

Finally, some formatting fixes were made (more to come on this in a separate PR)