### PR TITLE
linting: fix errors and surface CI lint result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ deploy-aca: ## Run deployment script for Azure Container Apps
 	./scripts/deploy-aca.sh
 
 test: ## Run PyTest (verbose)
-	pytest ./tests -v
+	pytest ./tests -vv
 	
 test-not-slow: ## Run PyTest (verbose, skip slow tests)
-	pytest ./tests -v -m "not slow"
+	pytest ./tests -vv -m "not slow"
 
 test-watch: ## Start PyTest Watch
 	ptw --clear ./tests

--- a/scripts/ci-lint.sh
+++ b/scripts/ci-lint.sh
@@ -15,4 +15,5 @@ if [[ -n "$GITHUB_BASE_REF" ]]; then
 fi
 
 echo "Running linter..."
-pylint "$script_dir/../src/aoai-api-simulator/"  --exit-zero
+echo "# Linter result" >> $GITHUB_STEP_SUMMARY
+pylint "$script_dir/../src/aoai-api-simulator/"  --exit-zero >> $GITHUB_STEP_SUMMARY

--- a/src/aoai-api-simulator/src/aoai_api_simulator/generator/openai.py
+++ b/src/aoai-api-simulator/src/aoai_api_simulator/generator/openai.py
@@ -477,9 +477,11 @@ async def azure_openai_embedding(context: RequestContext) -> Response | None:
                 {
                     "error": {
                         "code": "OperationNotSupported",
-                        "message": f"The embeddings operation does not work with the specified model, {deployment_name}. "
-                        + "Please choose different model and try again. "
-                        + "You can learn more about which models can be used with each operation here: https://go.microsoft.com/fwlink/?linkid=2197993.",
+                        "message": "The embeddings operation does not work with the specified model, "
+                        + deployment_name
+                        + ". Please choose different model and try again. "
+                        + "You can learn more about which models can be used with each operation here: "
+                        + "https://go.microsoft.com/fwlink/?linkid=2197993.",
                     }
                 }
             ),
@@ -532,9 +534,11 @@ async def azure_openai_completion(context: RequestContext) -> Response | None:
                 {
                     "error": {
                         "code": "OperationNotSupported",
-                        "message": f"The completions operation does not work with the specified model, {deployment_name}. "
-                        + "Please choose different model and try again. "
-                        + "You can learn more about which models can be used with each operation here: https://go.microsoft.com/fwlink/?linkid=2197993.",
+                        "message": "The completions operation does not work with the specified model, "
+                        + deployment_name
+                        + ". Please choose different model and try again. "
+                        + "You can learn more about which models can be used with each operation here: "
+                        + "https://go.microsoft.com/fwlink/?linkid=2197993.",
                     }
                 }
             ),
@@ -593,9 +597,11 @@ async def azure_openai_chat_completion(context: RequestContext) -> Response | No
                 {
                     "error": {
                         "code": "OperationNotSupported",
-                        "message": f"The chatCompletion operation does not work with the specified model, {deployment_name}. "
-                        + "Please choose different model and try again. "
-                        + "You can learn more about which models can be used with each operation here: https://go.microsoft.com/fwlink/?linkid=2197993.",
+                        "message": "The chatCompletion operation does not work with the specified model, "
+                        + deployment_name
+                        + ". Please choose different model and try again. "
+                        + "You can learn more about which models can be used with each operation here: "
+                        + "https://go.microsoft.com/fwlink/?linkid=2197993.",
                     }
                 }
             ),


### PR DESCRIPTION
- fixup linter errors that slipped through in PRs
- Update `ci-lint.sh` to send linter output to step summary

Example step summary output:

![image](https://github.com/user-attachments/assets/9fb6d048-b8c5-44d6-a415-6ee1888e7f12)

