### PR TITLE
fix: update OpenAIDeployment.model to use model model_catalogue

### DIFF
--- a/src/aoai-api-simulator/src/aoai_api_simulator/config_loader.py
+++ b/src/aoai-api-simulator/src/aoai_api_simulator/config_loader.py
@@ -75,35 +75,40 @@ def _load_openai_deployments(logger: logging.Logger) -> dict[str, OpenAIDeployme
 
 def _default_openai_deployments() -> dict[str, OpenAIDeployment]:
     # Default set of OpenAI deployment configurations for when none are provided
+    embedding_model = model_catalogue["text-embedding-ada-002"]
+    gpt_35_turbo_model = model_catalogue["gpt-3.5-turbo"]
+    whisper_model = model_catalogue["whisper"]
     return {
         "embedding": OpenAIDeployment(
-            name="embedding", model="text-embedding-ada-002", tokens_per_minute=20000, embedding_size=1536
+            name="embedding", model=embedding_model, tokens_per_minute=20000, embedding_size=1536
         ),
         "gpt-35-turbo-1k-token": OpenAIDeployment(
-            name="gpt-35-turbo-1k-token", model="gpt-3.5-turbo", tokens_per_minute=1000
+            name="gpt-35-turbo-1k-token", model=gpt_35_turbo_model, tokens_per_minute=1000
         ),
         "gpt-35-turbo-2k-token": OpenAIDeployment(
-            name="gpt-35-turbo-2k-token", model="gpt-3.5-turbo", tokens_per_minute=2000
+            name="gpt-35-turbo-2k-token", model=gpt_35_turbo_model, tokens_per_minute=2000
         ),
         "gpt-35-turbo-5k-token": OpenAIDeployment(
-            name="gpt-35-turbo-5k-token", model="gpt-3.5-turbo", tokens_per_minute=5000
+            name="gpt-35-turbo-5k-token", model=gpt_35_turbo_model, tokens_per_minute=5000
         ),
         "gpt-35-turbo-10k-token": OpenAIDeployment(
-            name="gpt-35-turbo-10k-token", model="gpt-3.5-turbo", tokens_per_minute=10000
+            name="gpt-35-turbo-10k-token", model=gpt_35_turbo_model, tokens_per_minute=10000
         ),
         "gpt-35-turbo-20k-token": OpenAIDeployment(
-            name="gpt-35-turbo-20k-token", model="gpt-3.5-turbo", tokens_per_minute=20000
+            name="gpt-35-turbo-20k-token", model=gpt_35_turbo_model, tokens_per_minute=20000
         ),
         "gpt-35-turbo-50k-token": OpenAIDeployment(
-            name="gpt-35-turbo-50k-token", model="gpt-3.5-turbo", tokens_per_minute=50000
+            name="gpt-35-turbo-50k-token", model=gpt_35_turbo_model, tokens_per_minute=50000
         ),
         "gpt-35-turbo-100k-token": OpenAIDeployment(
-            name="gpt-35-turbo-100k-token", model="gpt-3.5-turbo", tokens_per_minute=100000
+            name="gpt-35-turbo-100k-token", model=gpt_35_turbo_model, tokens_per_minute=100000
         ),
         "gpt-35-turbo-100m-token": OpenAIDeployment(
-            name="gpt-35-turbo-100m-token", model="gpt-3.5-turbo", tokens_per_minute=100000000
+            name="gpt-35-turbo-100m-token", model=gpt_35_turbo_model, tokens_per_minute=100000000
         ),
-        "whisper": OpenAIDeployment(name="whisper", model="whisper", requests_per_minute=3),
+        "whisper": OpenAIDeployment(
+            name="whisper", model=whisper_model, requests_per_minute=3
+        )
     }
 
 


### PR DESCRIPTION
This pull request includes changes to the `src/aoai-api-simulator/src/aoai_api_simulator/config_loader.py` file to fix how default OpenAI deployment configurations are defined. 

This is in response to a recent change where `model` was changed from a `str` to a `OpenAIModel`. The implementation leverages the `model_catalogue` for consistency.