### PR TITLE
fix: re-introduce support for ARM

### DIFF
--- a/src/aoai-api-simulator/Dockerfile
+++ b/src/aoai-api-simulator/Dockerfile
@@ -1,13 +1,10 @@
 ARG network_type=unrestricted
 ARG TIKTOKEN_CACHE_PATH=/app/tiktoken_cache
 
-FROM python:3.12.1-slim-bullseye AS base
+FROM python:3.12.1-bookworm AS base
 WORKDIR /app
 
 FROM base AS simulator-unrestricted-network
-
-# Install gcc and python3-dev to support ARM architecture
-RUN apt-get update && apt-get install -y gcc python3-dev
 
 COPY ./requirements.txt ./
 RUN pip install -r requirements.txt


### PR DESCRIPTION
We have recently run into issues running the simulator on ARM. This is due to a "Hash Sum mismatch" error that occurs during the Docker build process, because of `RUN apt-get update && apt-get install -y gcc python3-dev`.

This PR includes a change to the `Dockerfile` to update of the base image from `python:3.12.1-slim-bullseye` to `python:3.12.1-bookworm`.

In testing, no other installs / packages are required.